### PR TITLE
Add PKGBUILD for ArchLinux with other changes

### DIFF
--- a/ArchLinux/.SRCINFO
+++ b/ArchLinux/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = multiverse-git
+	pkgdesc = A decentralized version control system for peer-to-peer software development.
+	pkgver = d945c32
+	pkgrel = 1
+	url = http://www.multiverse-vcs.com/
+	arch = aarch64
+	arch = x86_64
+	makedepends = git
+	makedepends = go>=1.16
+	depends = go>=1.16
+	provides = multiverse
+	source = multiverse-git::git+https://github.com/multiverse-vcs/go-multiverse
+	sha256sums = SKIP
+
+pkgname = multiverse-git
+

--- a/ArchLinux/.gitignore
+++ b/ArchLinux/.gitignore
@@ -1,0 +1,4 @@
+pkg
+src
+*.pkg.tar.*
+multiverse*

--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer Keenan Nemetz <keenan.nemetz@gmail.com>
+# Maintainer teknomunk <https://github.com/teknomunk>
+pkgname=multiverse-git
+pkgver=d945c32
+pkgrel=1
+pkgdesc="A decentralized version control system for peer-to-peer software development."
+arch=(aarch64 x86_64)
+url=http://www.multiverse-vcs.com/
+licence=("AGPL3")
+provides=(multiverse)
+depends=("go>=1.16")
+makedepends=("git" "go>=1.16")
+source=(${pkgname}::git+https://github.com/multiverse-vcs/go-multiverse)
+sha256sums=("SKIP")
+check(){
+	cd ${srcdir}/${pkgname}
+	export GOPATH=${srcdir}/go
+	make test
+}
+pkgver(){
+	cd ${srcdir}/${pkgname}
+	git log --format=%h -1
+}
+prepare(){
+	cd ${srcdir}/${pkgname}
+	sed -i "s/GOCC = go1.16beta1/GOCC = go1.16/" Makefile
+	export GOPATH=${srcdir}/go
+	go get golang.org/dl/go1.16
+	PATH=${GOPATH}/bin:${PATH} go1.16 download
+}
+build(){
+	export GOPATH=${srcdir}/go
+	cd ${srcdir}/${pkgname}
+	PATH=${GOPATH}/bin:${PATH} make
+}
+package(){
+	cd ${srcdir}/${pkgname}
+	export GOPATH=${srcdir}/go
+	make install GOBIN=${pkgdir}/usr/bin PATH=${GOPATH}/bin:${PATH}
+	install -Dm644 ${srcdir}/${pkgname}/multiverse.service ${pkgdir}/usr/lib/systemd/system/multiverse.service
+	sed -i "s_exec \$HOME/go/bin/multi daemon_exec /usr/bin/multi daemon_" ${pkgdir}/usr/lib/systemd/system/multiverse.service
+}

--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer Keenan Nemetz <keenan.nemetz@gmail.com>
 # Maintainer teknomunk <https://github.com/teknomunk>
 pkgname=multiverse-git
-pkgver=d945c32
+pkgver=678f40f
 pkgrel=1
 pkgdesc="A decentralized version control system for peer-to-peer software development."
 arch=(aarch64 x86_64)
@@ -13,8 +13,10 @@ makedepends=("git" "go>=1.16")
 source=(${pkgname}::git+https://github.com/multiverse-vcs/go-multiverse)
 sha256sums=("SKIP")
 check(){
-	cd ${srcdir}/${pkgname}
 	export GOPATH=${srcdir}/go
+	export PATH=${GOPATH}/bin:${PATH}
+
+	cd ${srcdir}/${pkgname}
 	make test
 }
 pkgver(){
@@ -22,21 +24,28 @@ pkgver(){
 	git log --format=%h -1
 }
 prepare(){
-	cd ${srcdir}/${pkgname}
-	sed -i "s/GOCC = go1.16beta1/GOCC = go1.16/" Makefile
 	export GOPATH=${srcdir}/go
+	export PATH=${GOPATH}/bin:${PATH}
+
+	cd ${srcdir}/${pkgname}
 	go get golang.org/dl/go1.16
-	PATH=${GOPATH}/bin:${PATH} go1.16 download
+	go1.16 download
 }
 build(){
 	export GOPATH=${srcdir}/go
+	export PATH=${GOPATH}/bin:${PATH}
+
 	cd ${srcdir}/${pkgname}
-	PATH=${GOPATH}/bin:${PATH} make
+	make
 }
 package(){
-	cd ${srcdir}/${pkgname}
 	export GOPATH=${srcdir}/go
+	export PATH=${GOPATH}/bin:${PATH}
+
+	cd ${srcdir}/${pkgname}
 	make install GOBIN=${pkgdir}/usr/bin PATH=${GOPATH}/bin:${PATH}
-	install -Dm644 ${srcdir}/${pkgname}/multiverse.service ${pkgdir}/usr/lib/systemd/system/multiverse.service
-	sed -i "s_exec \$HOME/go/bin/multi daemon_exec /usr/bin/multi daemon_" ${pkgdir}/usr/lib/systemd/system/multiverse.service
+	mkdir -p ${pkgdir}/var/lib/multi/
+	chown 5000:5000 ${pkgdir}/var/lib/multi
+	install -Dm644 ${srcdir}/${pkgname}/misc/multiverse.service ${pkgdir}/usr/lib/systemd/system/multiverse.service
+	install -Dm644 ${srcdir}/${pkgname}/misc/multi-user.conf ${pkgdir}/usr/lib/sysusers.d/multi.conf
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOCC = go1.16beta1
+GOCC = go1.16
 
 .PHONY: multi install test multi-cross
 .PHONY: multi-darwin multi-darwin-386 multi-darwin-amd64

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 Go 1.16 or higher is required.
 
 ```bash
-$ go get golang.org/dl/go1.16beta1
-$ go1.16beta1 download
+$ go get golang.org/dl/go1.16
+$ go1.16 download
 ```
 
 Build and install from sources.
@@ -40,7 +40,7 @@ $ make install
 ```
 USAGE:
    multi [global options] command [command options] [arguments...]
-   
+
 COMMANDS:
    branch   List, create, or delete branches
    commit   Record changes
@@ -63,3 +63,4 @@ Multiverse follows the [Contributor Covenant](https://contributor-covenant.org/v
 ### License
 
 GNU Affero General Public License v3.0
+

--- a/misc/multi-user.conf
+++ b/misc/multi-user.conf
@@ -1,0 +1,4 @@
+u multi - "Decentralized VCS Server" /var/lib/multi
+g multi -
+m multi multi
+

--- a/misc/multi-user.conf
+++ b/misc/multi-user.conf
@@ -1,4 +1,4 @@
-u multi - "Decentralized VCS Server" /var/lib/multi
-g multi -
+u multi 5000 "Decentralized VCS Server" /var/lib/multi
+g multi 5000
 m multi multi
 

--- a/misc/multiverse.service
+++ b/misc/multiverse.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Multiverse daemon
 After=network.target
-Requires=ipfs.service
 
 [Service]
 User=multi
 Group=multi
-ExecStart=/bin/bash -c "exec /usr/bin/multi daemon"
+ExecStart=/usr/bin/multi daemon
 Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/misc/multiverse.service
+++ b/misc/multiverse.service
@@ -4,7 +4,9 @@ After=network.target
 Requires=ipfs.service
 
 [Service]
-ExecStart=/bin/bash -c "exec $HOME/go/bin/multi daemon"
+User=multi
+Group=multi
+ExecStart=/bin/bash -c "exec /usr/bin/multi daemon"
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
Built on top of #16, includes the following changes:

 * adds an ArchLinux PKGBUILD
 * updates to the systemd service file to run as a global service as a restricted user (multi uid=5000, homedir=/var/lib/multi/)
 * incorporates sed patches from original PKGBUILD into respective files
 * updates README.md to change go1.16beta1 to go1.16