### PR TITLE
Add configuration file option for LibP2P listen addresses

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -17,11 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p-tls"
 )
 
-// ListenAddresses is a list of addresses to listen on.
-var ListenAddresses = []string{
-	"/ip4/0.0.0.0/tcp/9000",
-}
-
 const (
 	// LowWater is the minimum amount of connections to keep.
 	LowWater = 100
@@ -32,13 +27,13 @@ const (
 )
 
 // NewHost returns a new libp2p host and router.
-func NewHost(ctx context.Context, priv crypto.PrivKey) (host.Host, routing.Routing, error) {
+func NewHost(ctx context.Context, priv crypto.PrivKey, listen_addresses []string) (host.Host, routing.Routing, error) {
 	var router routing.Routing
 	var err error
 
 	host, err := libp2p.New(ctx,
 		libp2p.Identity(priv),
-		libp2p.ListenAddrStrings(ListenAddresses...),
+		libp2p.ListenAddrStrings(listen_addresses...),
 		libp2p.Security(libp2ptls.ID, libp2ptls.New),
 		libp2p.Security(noise.ID, noise.New),
 		libp2p.DefaultTransports,

--- a/peer/config.go
+++ b/peer/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// PrivateKey is the base64 encoded private key.
 	PrivateKey string `json:"private_key"`
 
+	// Listen addresses for LibP2P
+	ListenAddresses []string `json:"listen_addresses"`
+
 	path string
 }
 
@@ -40,6 +43,9 @@ func NewConfig(root string) (*Config, error) {
 		Author:     data.NewAuthor(),
 		PrivateKey: encoded,
 		path:       filepath.Join(root, ConfigFile),
+		ListenAddresses: []string{
+			"/ip4/0.0.0.0/tcp/9000",
+		},
 	}
 
 	return &config, nil

--- a/peer/node.go
+++ b/peer/node.go
@@ -41,7 +41,7 @@ func New(ctx context.Context, dstore datastore.Batching, config *Config) (*Node,
 		return nil, err
 	}
 
-	host, router, err := p2p.NewHost(ctx, priv)
+	host, router, err := p2p.NewHost(ctx, priv, config.ListenAddresses)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow LibP2P listen addresses to be customized in the user's configuration file. This allows #19 to be satisfied.